### PR TITLE
fix type

### DIFF
--- a/src/filament_dryer.py
+++ b/src/filament_dryer.py
@@ -193,9 +193,11 @@ class filament_dryer:
             return {
                 'name': self.name,
                 'config': "{'target_humidity': '%f', 'interval': '%i'}" % (self.target_humidity, self.interval),
-                'info': "{'humidity': '%i', 'temperature': '%i', 'dry_mode': '%s', 'dry_time': '%i:%02i:%02i'}" % (self>            }
+                'info': "{'humidity': '%i', 'temperature': '%i', 'dry_mode': '%s', 'dry_time': '%i:%02i:%02i'}" % (self.sensor.humidity, self.sensor.temp, self.dry_mode, hh, mm, ss)
+            }
         except Exception:
             return { }
 
 def load_config_prefix(config):
     return filament_dryer(config)
+


### PR DESCRIPTION
there was a probably typo which caused "Internal error during connect: closing parenthesis '}' does not match opening parenthesis '(' (filament_dryer.py, line 196)" error. this one fixes it